### PR TITLE
Removed HTTP protocol for images

### DIFF
--- a/iframe.html
+++ b/iframe.html
@@ -71,7 +71,7 @@
 </head>
 <body style="padding:0px;" onselectstart="return false">
   <div id="wma_widget">
-    <img id="wmaspinner" src="http://upload.wikimedia.org/wikipedia/commons/4/42/Loading.gif">
+    <img id="wmaspinner" src="//upload.wikimedia.org/wikipedia/commons/4/42/Loading.gif">
   </div>
 <script>
   $(function(){

--- a/iframe_dev.html
+++ b/iframe_dev.html
@@ -71,7 +71,7 @@
 </head>
 <body style="padding:0px;" onselectstart="return false">
   <div id="wma_widget">
-    <img id="wmaspinner" src="http://upload.wikimedia.org/wikipedia/commons/4/42/Loading.gif">
+    <img id="wmaspinner" src="//upload.wikimedia.org/wikipedia/commons/4/42/Loading.gif">
   </div>
 <script>
   $(function(){

--- a/wikiminiatlas.css
+++ b/wikiminiatlas.css
@@ -162,7 +162,7 @@ a.label9 {
 }
 /* Event */
 a.label10 {
-   background-image:url('http://upload.wikimedia.org/wikipedia/commons/0/0a/Wma_event_11.png');
+   background-image:url('//upload.wikimedia.org/wikipedia/commons/0/0a/Wma_event_11.png');
    padding-left:13px;
    filter:alpha(opacity=50); 
    -moz-opacity: 0.5; 

--- a/wikiminiatlas_dev.css
+++ b/wikiminiatlas_dev.css
@@ -162,7 +162,7 @@ a.label9 {
 }
 /* Event */
 a.label10 {
-   background-image:url('http://upload.wikimedia.org/wikipedia/commons/0/0a/Wma_event_11.png');
+   background-image:url('//upload.wikimedia.org/wikipedia/commons/0/0a/Wma_event_11.png');
    padding-left:13px;
    filter:alpha(opacity=50); 
    -moz-opacity: 0.5; 


### PR DESCRIPTION
Little security fix. If Wikipedia is loaded via HTTPS, then all resources should be loaded via HTTPS.
