### PR TITLE
Make jQuery 3 compatible

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         e.source.postMessage('1,1','*');
       }
     }
-    $(window).bind('message',wmaMessageHub);
+    $(window).on('message',wmaMessageHub);
   </script>
 </head>
 <body>

--- a/index_dev.html
+++ b/index_dev.html
@@ -18,7 +18,7 @@ a { text-decoration:none; }
       e.source.postMessage('1,1','*');
     }
   }
-  $(window).bind('message',wmaMessageHub);
+  $(window).on('message',wmaMessageHub);
 </script>
 </head>
 <body>

--- a/wikiminiatlas.js
+++ b/wikiminiatlas.js
@@ -488,7 +488,7 @@ jQuery(function ($) {
    }
   }
 
-  mapbutton.bind( 'click', { param:
+  mapbutton.on( 'click', { param:
    marker.lat + '_' + marker.lon + '_' +
    wc.width + '_' + wc.height + '_' +
    site + '_' + zoomlevel + '_' + language + '&globe=' + globe }, showIFrame );
@@ -507,7 +507,7 @@ jQuery(function ($) {
    .css('padding', rtl ? '0px 3px 0px 0px' : '0px 0px 0px 3px' ).css('cursor', 'pointer')
    .attr('src', wc.buttonImage).attr('srcset', wc.buttonImage + ' 1x, ' + wc.buttonImage2x + ' 2x')
    .addClass('wmamapbutton noprint')
-   .bind( 'click', { param:
+   .on( 'click', { param:
     alat + '_' + alon + '_' +
     wc.width + '_' + wc.height + '_' +
     site + '_' + zoomlevel + '_' + language
@@ -691,13 +691,13 @@ jQuery(function ($) {
         adjusthelper();
 
         $('body')
-         .bind('mouseup.wmaresize', function(e) {
-          $('body').unbind('mousemove.wmaresize');
-          $('body').unbind('mouseup.wmaresize');
+         .on('mouseup.wmaresize', function(e) {
+          $('body').off('mousemove.wmaresize');
+          $('body').off('mouseup.wmaresize');
           idle = true;
           wi.resizehelper.hide();
          } )
-         .bind('mousemove.wmaresize', function(e) {
+         .on('mousemove.wmaresize', function(e) {
           wc.width -= dir*(e.pageX-lastx);
           wc.height += (e.pageY-lasty);
           lastx = e.pageX; lasty = e.pageY;
@@ -713,7 +713,7 @@ jQuery(function ($) {
    );
   })();
 
-  $(window).bind('message', messageHub);
+  $(window).on('message', messageHub);
 
   // Fire event for other code to extend or integrate with WMA
   if (initPromises.length) {

--- a/wmacore.js
+++ b/wmacore.js
@@ -708,7 +708,7 @@ function wikiminiatlasInstall(wma_widget, url_params)
     $(document).on('keydown', wmaKeypress);
     $(document).on('contextmenu', function() { return false; });
 
-    $('body').bind('dragstart', function() { return false; })
+    $('body').on('dragstart', function() { return false; })
     $('#wma_map').click(function(e) {
         // only count clicks if the mouse pointer has not moved between mouse down and mouse up!
         var r = wmaMouseCoords(e); //TODO: VERIFY this!!!!
@@ -797,7 +797,7 @@ function wikiminiatlasInstall(wma_widget, url_params)
     // initialize message passing
     if (window.postMessage)
     {
-      $(window).bind('message', wmaReceiveMessage);
+      $(window).on('message', wmaReceiveMessage);
       if (window != window.top)
       {
         try {

--- a/wmacore_dev.js
+++ b/wmacore_dev.js
@@ -708,7 +708,7 @@ function wikiminiatlasInstall(wma_widget, url_params)
     $(document).on('keydown', wmaKeypress);
     $(document).on('contextmenu', function() { return false; });
 
-    $('body').bind('dragstart', function() { return false; })
+    $('body').on('dragstart', function() { return false; })
     $('#wma_map').click(function(e) {
         // only count clicks if the mouse pointer has not moved between mouse down and mouse up!
         var r = wmaMouseCoords(e); //TODO: VERIFY this!!!!
@@ -797,7 +797,7 @@ function wikiminiatlasInstall(wma_widget, url_params)
     // initialize message passing
     if (window.postMessage)
     {
-      $(window).bind('message', wmaReceiveMessage);
+      $(window).on('message', wmaReceiveMessage);
       if (window != window.top)
       {
         try {


### PR DESCRIPTION
bind and unbind have been deprecated in jQuery for a long time.
Wikimedia is switching to jQuery v3, where these deprecated methods will
be removed. These calls have therefore been replaced with .on and .off
calls.

See also https://phabricator.wikimedia.org/T124742